### PR TITLE
Update import paths to match the new name

### DIFF
--- a/cmd/cabpk/cabpk.go
+++ b/cmd/cabpk/cabpk.go
@@ -17,8 +17,8 @@ limitations under the License.
 package cabpk
 
 import (
-	"github.com/ashish-amarnath/capiyaml/cmd/constants"
-	"github.com/ashish-amarnath/capiyaml/cmd/serialize"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/constants"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/serialize"
 	infrav1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
 )

--- a/cmd/capa/capa.go
+++ b/cmd/capa/capa.go
@@ -17,8 +17,8 @@ limitations under the License.
 package capa
 
 import (
-	"github.com/ashish-amarnath/capiyaml/cmd/constants"
-	"github.com/ashish-amarnath/capiyaml/cmd/serialize"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/constants"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/serialize"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha2"
 )
 

--- a/cmd/capd/capd.go
+++ b/cmd/capd/capd.go
@@ -17,8 +17,8 @@ limitations under the License.
 package capd
 
 import (
-	"github.com/ashish-amarnath/capiyaml/cmd/constants"
-	"github.com/ashish-amarnath/capiyaml/cmd/serialize"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/constants"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/serialize"
 	dockerv1 "sigs.k8s.io/cluster-api-provider-docker/api/v1alpha2"
 )
 

--- a/cmd/capi/capi.go
+++ b/cmd/capi/capi.go
@@ -17,8 +17,8 @@ limitations under the License.
 package capi
 
 import (
-	"github.com/ashish-amarnath/capiyaml/cmd/constants"
-	"github.com/ashish-amarnath/capiyaml/cmd/serialize"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/constants"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/serialize"
 	v1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 )

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ashish-amarnath/capiyaml/cmd/cabpk"
-	"github.com/ashish-amarnath/capiyaml/cmd/capa"
-	"github.com/ashish-amarnath/capiyaml/cmd/capd"
-	"github.com/ashish-amarnath/capiyaml/cmd/capi"
-	"github.com/ashish-amarnath/capiyaml/cmd/constants"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/cabpk"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/capa"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/capd"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/capi"
+	"github.com/ashish-amarnath/capi-yaml-gen/cmd/constants"
 )
 
 func getInfraClusterYaml(infraProvider, cName, cNamespace string) (string, string, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ashish-amarnath/capiyaml
+module github.com/ashish-amarnath/capi-yaml-gen
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "github.com/ashish-amarnath/capiyaml/cmd"
+import "github.com/ashish-amarnath/capi-yaml-gen/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
It looks like the project was renamed, but the import paths are still pointing to the old name (though github conveniently provides a redirect).