### PR TITLE
Fixes YAML bug

### DIFF
--- a/cmd/capa/capa.go
+++ b/cmd/capa/capa.go
@@ -73,12 +73,12 @@ func (p Provider) SetBootstrapConfigInfraValues(c *bootstrapv1.KubeadmConfig) {
 	}
 	if c.Spec.InitConfiguration != nil {
 		c.Spec.InitConfiguration.NodeRegistration = bootstrapv1beta1.NodeRegistrationOptions{
-			Name:             "'{{ ds.meta_data.hostname }}'",
+			Name:             "{{ ds.meta_data.hostname }}",
 			KubeletExtraArgs: extraArgs,
 		}
 	} else if c.Spec.JoinConfiguration != nil {
 		c.Spec.JoinConfiguration.NodeRegistration = bootstrapv1beta1.NodeRegistrationOptions{
-			Name:             "'{{ ds.meta_data.hostname }}'",
+			Name:             "{{ ds.meta_data.hostname }}",
 			KubeletExtraArgs: extraArgs,
 		}
 	}
@@ -103,7 +103,7 @@ func (p Provider) SetBootstrapConfigTemplateInfraValues(t *bootstrapv1.KubeadmCo
 	}
 	if t.Spec.Template.Spec.JoinConfiguration != nil {
 		t.Spec.Template.Spec.JoinConfiguration.NodeRegistration = bootstrapv1beta1.NodeRegistrationOptions{
-			Name:             "'{{ ds.meta_data.hostname }}'",
+			Name:             "{{ ds.meta_data.hostname }}",
 			KubeletExtraArgs: extraArgs,
 		}
 	}

--- a/cmd/testdata/default-capa-no-machine-deployment.golden
+++ b/cmd/testdata/default-capa-no-machine-deployment.golden
@@ -96,7 +96,7 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: aws
-      name: '''{{ ds.meta_data.hostname }}'''
+      name: '{{ ds.meta_data.hostname }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: AWSMachine
@@ -144,4 +144,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: aws
-      name: '''{{ ds.meta_data.hostname }}'''
+      name: '{{ ds.meta_data.hostname }}'


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

`'''thing'''`

is the literal
`'thing'` when interpolated, it's the same as `"'thing'"` which is wrong as I ended up with this error when trying to start a cluster:

name: Invalid value: "'ip-10-0-0-27.us-west-2.compute.internal'": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
