### PR TITLE
🐛 Fix bug on machine deployment

### DIFF
--- a/cmd/capi/capi.go
+++ b/cmd/capi/capi.go
@@ -84,15 +84,17 @@ func GetCoreControlPlaneMachine(name, namespace, clusterName, version string, bo
 
 // GetCoreMachineDeployment returns a cluster-api machine deployment object
 func GetCoreMachineDeployment(clusterName, name, namespace, version string, replicas int32, machineTemplate, bootstrapConfigTemplate object) *clusterv1.MachineDeployment {
+	labels := map[string]string{
+		clusterv1.ClusterLabelName: clusterName,
+	}
+
 	dep := &clusterv1.MachineDeployment{}
 	dep.Name = name
 	dep.Namespace = namespace
 	dep.Spec.Replicas = &replicas
 	dep.Spec.ClusterName = clusterName
+	dep.Labels = labels
 
-	labels := map[string]string{
-		clusterv1.ClusterLabelName: clusterName,
-	}
 	dep.Spec.Selector.MatchLabels = labels
 	dep.Spec.Template.ObjectMeta.Labels = labels
 	dep.Spec.Template.Spec.Version = &version

--- a/cmd/testdata/default-capd.golden
+++ b/cmd/testdata/default-capd.golden
@@ -115,6 +115,8 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
   name: worker-md
   namespace: default
 spec:


### PR DESCRIPTION
Machine deployments weren't getting deleted when deleting a cluster. I tracked it down to a missing cluster label.

Signed-off-by: Chuck Ha <chuckh@vmware.com>